### PR TITLE
Update theblues and increase timeout

### DIFF
--- a/charmstore/lib.py
+++ b/charmstore/lib.py
@@ -25,6 +25,8 @@ AVAILABLE_INCLUDES = [
     'id',
 ]
 
+DEFAULT_TIMEOUT = 10
+
 
 class CharmStore(object):
     def __init__(self, api='https://api.jujucharms.com/v4'):
@@ -79,7 +81,7 @@ class Entity(object):
 
         return e
 
-    def __init__(self, id=None, api='https://api.jujucharms.com/v4'):
+    def __init__(self, id=None, timeout=DEFAULT_TIMEOUT):
         self.id = None
         self.name = None
         self.owner = None
@@ -97,7 +99,7 @@ class Entity(object):
         self.stats = {}
 
         self.raw = {}
-        self.theblues = charmstore.CharmStore(api)
+        self.theblues = charmstore.CharmStore(timeout=timeout)
 
         if id:
             self.load(
@@ -137,7 +139,7 @@ class Entity(object):
 
 
 class Charm(Entity):
-    def __init__(self, id=None, api='https://api.jujucharms.com/v4'):
+    def __init__(self, id=None, timeout=DEFAULT_TIMEOUT):
         self.summary = None
         self.description = None
 
@@ -152,7 +154,7 @@ class Charm(Entity):
         self.bundles = []
         self.terms = []
 
-        super(Charm, self).__init__(id, api)
+        super(Charm, self).__init__(id, timeout)
 
     def related(self):
         data = self.raw.get('charm-related')
@@ -205,12 +207,12 @@ class Charm(Entity):
 
 
 class Bundle(Entity):
-    def __init__(self, id=None, api='https://api.jujucharms.com/v4'):
+    def __init__(self, id=None, timeout=DEFAULT_TIMEOUT):
         self.count = {'machines': 0, 'units': 0}
         self.relations = []
         self.services = None
 
-        super(Charm, self).__init__(id, api)
+        super(Charm, self).__init__(id, timeout)
 
     def load(self, charm_data):
         if 'charm-metadata' not in charm_data:

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ from setuptools import setup
 
 setup(
     name='libcharmstore',
-    version='0.0.3',
+    version='0.0.4',
     packages=['charmstore'],
     maintainer='Marco Ceppi',
     install_requires=[
-        'theblues>=0.1.1,<1.0',
+        'theblues>=0.3.7,<1.0',
     ],
     maintainer_email='marco@ceppi.net',
     description=('Library to access charmstore data'),


### PR DESCRIPTION
To resolve this:

```
Traceback (most recent call last):
  File "/tmp/cwr-tmp-WVRL51/bundletester-z83TkZ/tmpaizXag/tests/01-bundle.py", line 48, in setUpClass
    cls.d.load(bundle)
  File "/usr/local/lib/python3.5/dist-packages/amulet/deployer.py", line 157, in load
    series=self.series
  File "/usr/local/lib/python3.5/dist-packages/amulet/deployer.py", line 208, in add
    service_name, charm, branch=branch, series=service['series'])
  File "/usr/local/lib/python3.5/dist-packages/amulet/charm.py", line 57, in fetch
    series=series)
  File "/usr/local/lib/python3.5/dist-packages/amulet/charm.py", line 42, in get_charm
    return Charm(with_series(charm_path, series))
  File "/usr/local/lib/python3.5/dist-packages/charmstore/lib.py", line 155, in __init__
    super(Charm, self).__init__(id, api)
  File "/usr/local/lib/python3.5/dist-packages/charmstore/lib.py", line 105, in __init__
    AVAILABLE_INCLUDES).get('Meta')
  File "/usr/local/lib/python3.5/dist-packages/theblues/charmstore.py", line 107, in _meta
    data = self._get(url)
  File "/usr/local/lib/python3.5/dist-packages/theblues/charmstore.py", line 78, in _get
    raise ServerError(message)
theblues.errors.ServerError: Request timed out: https://api.jujucharms.com/v4/~bigdata-dev/xenial/apache-flume-hdfs-37/meta/any?include=bundle-machine-count&include=bundle-metadata&include=bundle-unit-count&include=bundles-containing&include=charm-actions&include=charm-config&include=charm-metadata&include=common-info&include=extra-info&include=revision-info&include=stats&include=supported-series&include=manifest&include=tags&include=promulgated&include=perm&include=id timeout: 3.05
```