### PR TITLE
Specify CS endpoint v4 when calling the blues

### DIFF
--- a/charmstore/lib.py
+++ b/charmstore/lib.py
@@ -26,12 +26,13 @@ AVAILABLE_INCLUDES = [
 ]
 
 DEFAULT_TIMEOUT = 10
+DEFAULT_CS_API_URL = 'https://api.jujucharms.com/v4'
 
 
 class CharmStore(object):
-    def __init__(self, api='https://api.jujucharms.com/v4'):
+    def __init__(self, api=DEFAULT_CS_API_URL):
         super(CharmStore, self).__init__()
-        self.theblues = charmstore.CharmStore(api)
+        self.theblues = charmstore.CharmStore(url=api)
 
     def requires(self, interfaces=[], limit=None):
         return self.interfaces(requires=interfaces)
@@ -81,7 +82,8 @@ class Entity(object):
 
         return e
 
-    def __init__(self, id=None, timeout=DEFAULT_TIMEOUT):
+    def __init__(self, id=None, api=DEFAULT_CS_API_URL,
+                 timeout=DEFAULT_TIMEOUT):
         self.id = None
         self.name = None
         self.owner = None
@@ -99,7 +101,7 @@ class Entity(object):
         self.stats = {}
 
         self.raw = {}
-        self.theblues = charmstore.CharmStore(timeout=timeout)
+        self.theblues = charmstore.CharmStore(url=api, timeout=timeout)
 
         if id:
             self.load(
@@ -139,7 +141,8 @@ class Entity(object):
 
 
 class Charm(Entity):
-    def __init__(self, id=None, timeout=DEFAULT_TIMEOUT):
+    def __init__(self, id=None, api=DEFAULT_CS_API_URL,
+                 timeout=DEFAULT_TIMEOUT):
         self.summary = None
         self.description = None
 
@@ -154,7 +157,7 @@ class Charm(Entity):
         self.bundles = []
         self.terms = []
 
-        super(Charm, self).__init__(id, timeout)
+        super(Charm, self).__init__(id, api=api, timeout=timeout)
 
     def related(self):
         data = self.raw.get('charm-related')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name='libcharmstore',
-    version='0.0.4',
+    version='0.0.5',
     packages=['charmstore'],
     maintainer='Marco Ceppi',
     install_requires=[


### PR DESCRIPTION
The OpenStack amulet tests started failing recently. On inspection this
appeared to be due to charms being deployed with the wrong series. This seems
to be due to a recent commit that removed the api URL from calls to theblues.
Previously theblues was called with an api url pointing at the cs v4 endpoint.

Fixes #2