### PR TITLE
Update to use theblues default url and fix lint

### DIFF
--- a/charmstore/lib.py
+++ b/charmstore/lib.py
@@ -1,8 +1,8 @@
 import os
-import re
 import json
 
 from theblues import charmstore
+from theblues.utils import API_URL
 from .error import CharmNotFound
 
 
@@ -27,7 +27,7 @@ AVAILABLE_INCLUDES = [
 ]
 
 DEFAULT_TIMEOUT = 10
-DEFAULT_CS_API_URL = 'https://api.jujucharms.com/v4'
+DEFAULT_CS_API_URL = API_URL
 
 
 class CharmStore(object):
@@ -121,7 +121,10 @@ class Entity(object):
 
     def file(self, path):
         if path not in self.files:
-            raise IOError(0, 'No such file in %s' % self.__class__.__name__.lower(), path)
+            raise IOError(
+                0,
+                'No such file in %s' % self.__class__.__name__.lower(),
+                path)
 
         return self.theblues._get(self.theblues.file_url(self.id, path)).text
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -37,7 +37,7 @@ class EntityTests(unittest.TestCase):
         charmstore.lib.Entity.from_data(CHARM.get('Meta'))
         _charmstore.CharmStore.assert_called_once_with(
             timeout=10.0,
-            url='https://api.jujucharms.com/v4')
+            url='https://api.jujucharms.com/charmstore/v5')
 
     @patch.dict(charmstore.lib.os.environ, {
         'CS_API_URL': 'alturl',


### PR DESCRIPTION
The api url for the charmstore was deprecated and when it was removed broke folks using tools that depend on libcharmstore. This forces it to rely on theblues underlying library so that we're not duplicating the default URL in multiple places. 

Also drive by lint fixes. 

I couldn't get the makefile to work for me to setup an environment. I'm not sure how the various variables were meant to be used to set it up. I manually tested the changed lines by setting up nose/etc myself and updating the tests to pass with the new url. 