### PR TITLE
Remove more charmstore query data

### DIFF
--- a/charmstore/lib.py
+++ b/charmstore/lib.py
@@ -6,7 +6,7 @@ from theblues.utils import API_URL
 from .error import CharmNotFound
 
 
-AVAILABLE_INCLUDES = [
+DEFAULT_INCLUDES = [
     'bundle-metadata',
     'charm-actions',
     'charm-config',
@@ -56,7 +56,7 @@ class CharmStore(object):
                sort=None, owner=None, series=None):
 
         if not includes:
-            includes = AVAILABLE_INCLUDES
+            includes = DEFAULT_INCLUDES
 
         result = self.theblues.search(text, includes, doc_type, limit,
                                       autocomplete, promulgated_only, tags,
@@ -105,7 +105,7 @@ class Entity(object):
         if id:
             self.load(
                 self.theblues._meta(id.replace('cs:', ''),
-                                    AVAILABLE_INCLUDES).get('Meta')
+                                    DEFAULT_INCLUDES).get('Meta')
             )
 
     def revisions(self):

--- a/charmstore/lib.py
+++ b/charmstore/lib.py
@@ -109,10 +109,10 @@ class Entity(object):
             )
 
     def revisions(self):
-        if self.revisions is None:
-            self.revisions = self.theblues._meta(self.id, ['revision-info']) \
+        if self._revisions is None:
+            self._revisions = self.theblues._meta(self.id, ['revision-info']) \
                 or {}
-        data = self.revisions.get('Revisions', [])
+        data = self._revisions.get('Revisions', [])
         return [self.__class__(e) for e in data]
 
     def file(self, path):

--- a/charmstore/lib.py
+++ b/charmstore/lib.py
@@ -94,7 +94,8 @@ class Entity(object):
         self.tags = None
         self.source = None
 
-        self.files = None
+        self._files_fetched = False
+        self.files = []
 
         self.stats = {}
 
@@ -115,10 +116,11 @@ class Entity(object):
         return [self.__class__(e) for e in data]
 
     def file(self, path):
-        if self.files is None:
+        if self._files_fetched is False:
             self.files = [
                 f.get('Name') for f in
                     self.theblues._meta(self.id, ['manifest']) ]
+            self._files_fetched = True
         if path not in self.files:
             raise IOError(
                 0,

--- a/charmstore/lib.py
+++ b/charmstore/lib.py
@@ -87,7 +87,7 @@ class Entity(object):
         self.series = None
         self.maintainer = None
         self.revision = None
-        self.revisions = None
+        self._revisions = None
         self.url = None
 
         self.approved = False

--- a/charmstore/lib.py
+++ b/charmstore/lib.py
@@ -7,21 +7,13 @@ from .error import CharmNotFound
 
 
 AVAILABLE_INCLUDES = [
-    'bundle-machine-count',
     'bundle-metadata',
-    'bundle-unit-count',
-    'bundles-containing',
     'charm-actions',
     'charm-config',
     'charm-metadata',
-    'common-info',
     'extra-info',
-    'revision-info',
-    'supported-series',
-    'manifest',
     'tags',
     'promulgated',
-    'perm',
     'id',
 ]
 
@@ -95,13 +87,14 @@ class Entity(object):
         self.series = None
         self.maintainer = None
         self.revision = None
+        self.revisions = None
         self.url = None
 
         self.approved = False
         self.tags = None
         self.source = None
 
-        self.files = []
+        self.files = None
 
         self.stats = {}
 
@@ -115,10 +108,17 @@ class Entity(object):
             )
 
     def revisions(self):
-        data = self.raw.get('revision-info', {}).get('Revisions', [])
+        if self.revisions is None:
+            self.revisions = self.theblues._meta(self.id, ['revision-info']) \
+                or {}
+        data = self.revisions.get('Revisions', [])
         return [self.__class__(e) for e in data]
 
     def file(self, path):
+        if self.files is None:
+            self.files = [
+                f.get('Name') for f in
+                    self.theblues._meta(self.id, ['manifest']) ]
         if path not in self.files:
             raise IOError(
                 0,


### PR DESCRIPTION
Additionally, makes two of the fields on-demand only, as
libcharmstore nor amulet actually reference them. The API
remains unchanged but the amount of data requested from
the charmstore should be dramatically reduced.